### PR TITLE
use key pairs instead of flat list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,9 @@
 BUILD_FILES = $(shell go list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}}\
 {{end}}' ./...)
 
-# XT_VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
-XT_VERSION = v1.0.0
+XT_VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
+# XT_VERSION = v1.0.0
 LDFLAGS := -X github.com/adamkobi/xt/internal/build.Version=$(XT_VERSION) $(LDFLAGS)
-ifdef XT_OAUTH_CLIENT_SECRET
-	LDFLAGS := -X github.com/adamkobi/xt/context.oauthClientID=$(XT_OAUTH_CLIENT_ID) $(LDFLAGS)
-	LDFLAGS := -X github.com/adamkobi/xt/context.oauthClientSecret=$(XT_OAUTH_CLIENT_SECRET) $(LDFLAGS)
-endif
 
 bin/xt: $(BUILD_FILES)
 	@go build -trimpath -ldflags "$(LDFLAGS)" -o "$@" ./cmd/main.go

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,12 @@ func main() {
 
 	cmdFactory := factory.New()
 	stderr := cmdFactory.IOStreams.ErrOut
+	_, err := cmdFactory.Config()
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to read configuration:  %s\n", err)
+		os.Exit(2)
+	}
+
 	if !cmdFactory.IOStreams.ColorEnabled() {
 		surveyCore.DisableColor = true
 	} else {
@@ -57,12 +63,6 @@ func main() {
 	}
 
 	rootCmd := root.NewCmd(cmdFactory, buildVersion, buildDate)
-
-	_, err := cmdFactory.Config()
-	if err != nil {
-		fmt.Fprintf(stderr, "failed to read configuration:  %s\n", err)
-		os.Exit(2)
-	}
 
 	if cmd, err := rootCmd.ExecuteC(); err != nil {
 		printError(stderr, err, cmd, hasDebug)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,12 +16,17 @@ type Config struct {
 }
 
 type FlowOptions struct {
-	Run          string   `yaml:"run"`
-	Selector     string   `yaml:"selector,omitempty"`
-	Keys         []string `yaml:"keys,omitempty"`
-	Root         string   `yaml:"root,omitempty"`
-	OutputFormat string   `yaml:"output_format"`
-	Print        bool     `yaml:"print,omitempty"`
+	Run          string `yaml:"run"`
+	Selector     string `yaml:"selector"`
+	Keys         []Pair `yaml:"keys,omitempty"`
+	Root         string `yaml:"root,omitempty"`
+	OutputFormat string `yaml:"output_format"`
+	Print        bool   `yaml:"print,omitempty"`
+}
+
+type Pair struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
 }
 
 type ProfileOptions struct {
@@ -201,11 +206,39 @@ func (f *FlowOptions) Validate() error {
 		if f.Root == "" {
 			return fmt.Errorf("parse must be set when using json type")
 		}
-		if len(f.Selector) == 0 {
-			return fmt.Errorf("selector must be set when using json type")
+		if len(f.Keys) < 1 {
+			return fmt.Errorf("keys must be set when using json type")
+		}
+		if f.Selector != "" {
+			valid := false
+			for _, key := range f.Keys {
+				if f.Selector == key.Name {
+					valid = true
+				}
+			}
+			if !valid {
+				return fmt.Errorf("selector must equal to one of keys provided")
+			}
 		}
 		return nil
 	default:
 		return nil
 	}
+}
+
+func (f *FlowOptions) GetSelector() *Pair {
+	for _, key := range f.Keys {
+		if f.Selector == key.Name {
+			return &key
+		}
+	}
+	return nil
+}
+
+func (f *FlowOptions) GetKeys() []string {
+	var keys []string
+	for _, key := range f.Keys {
+		keys = append(keys, key.Name)
+	}
+	return keys
 }

--- a/pkg/command/flow/add/add.go
+++ b/pkg/command/flow/add/add.go
@@ -67,8 +67,13 @@ func runAdd(opts *Options) error {
 			Help:    "Selector will return a picker to select the correct data set to collect from.\nFor nested keys use dot notation",
 		}
 
-		key := &survey.Input{
-			Message: "JSON key to parse from command output",
+		keyName := &survey.Input{
+			Message: "JSON key name, this will be used in next commands as placeholder for replacement",
+			Help:    "JSON key is collected from output and than can be used on next commands.\nFor nested keys use dot notation",
+		}
+
+		keyValue := &survey.Input{
+			Message: "JSON key path to parse from command output",
 			Help:    "JSON key is collected from output and than can be used on next commands.\nFor nested keys use dot notation",
 		}
 
@@ -99,10 +104,6 @@ func runAdd(opts *Options) error {
 		}
 
 		if cmd.OutputFormat == "json" {
-			if err := survey.AskOne(selector, &cmd.Selector); err != nil {
-				return err
-			}
-
 			addKeysAnswer := false
 			if err := survey.AskOne(addKeys, &addKeysAnswer); err != nil {
 				return err
@@ -113,8 +114,11 @@ func runAdd(opts *Options) error {
 					if !addMoreKeysAnswer {
 						break
 					}
-					var keyAnswer string
-					if err := survey.AskOne(key, &keyAnswer); err != nil {
+					var keyAnswer config.Pair
+					if err := survey.AskOne(keyName, &keyAnswer.Name); err != nil {
+						return err
+					}
+					if err := survey.AskOne(keyValue, &keyAnswer.Path); err != nil {
 						return err
 					}
 					cmd.Keys = append(cmd.Keys, keyAnswer)
@@ -123,6 +127,10 @@ func runAdd(opts *Options) error {
 						return err
 					}
 				}
+			}
+
+			if err := survey.AskOne(selector, &cmd.Keys[0]); err != nil {
+				return err
 			}
 
 			if err := survey.AskOne(table, &cmd.Print); err != nil {


### PR DESCRIPTION
[FIX]
* fixed bug in flow run where keys were not replaced correctly
* made template substitution more robust using key pairs
* fixed xt flow print to always print json in correct order
* fixed xt flow add to create keys with new convention